### PR TITLE
Drop snapshot repositories

### DIFF
--- a/daisy-parent/pom.xml
+++ b/daisy-parent/pom.xml
@@ -45,33 +45,6 @@
     <tag>HEAD</tag>
   </scm>
 
-  <repositories>
-    <repository>
-        <id>sonatype-nexus-snapshots</id>
-        <name>Sonatype Nexus Snapshots</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        <releases>
-            <enabled>false</enabled>
-        </releases>
-        <snapshots>
-            <enabled>true</enabled>
-        </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-        <id>sonatype-nexus-snapshots</id>
-        <name>Sonatype Nexus Snapshots</name>
-        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        <releases>
-            <enabled>false</enabled>
-        </releases>
-        <snapshots>
-            <enabled>true</enabled>
-        </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
-
   <distributionManagement>
     <snapshotRepository>
         <id>sonatype-nexus-snapshots</id>


### PR DESCRIPTION
Downloading snapshots from remote repositories should not be the default. If you want it you can add the repositories to your local settings.xml. For example, we already include them in our settings.xml that we use for Travis: https://raw.githubusercontent.com/daisy/maven-parents/travis/settings.xml

See https://github.com/daisy/pipeline-tasks/issues/75